### PR TITLE
Bug fixes in vqvae module

### DIFF
--- a/src/vqvae/attention.py
+++ b/src/vqvae/attention.py
@@ -23,7 +23,7 @@ class VanillaMultiHeadAttention(nn.Module):
 
         self.d_head = self.d_model // self.n_heads
         self.layernorm_qkv = nn.Sequential(
-            nn.LayerNorm(d_model), nn.Linear(d_model, d_model * 3, bias=bias)
+            nn.LayerNorm(d_model, bias=bias), nn.Linear(d_model, d_model * 3, bias=bias)
         )
         self.out_proj = nn.Linear(d_model, d_model, bias=bias)
 

--- a/src/vqvae/quantizer_module.py
+++ b/src/vqvae/quantizer_module.py
@@ -56,7 +56,7 @@ class BaseQuantizer(nn.Module):
             return self.codebook.weight
 
     def indices2embedding(self, indices: torch.IntTensor) -> torch.Tensor:
-        z_q = self.codebook[indices]
+        z_q = self.codebook(indices)
         return z_q
     
     def forward(self, z: torch.Tensor) -> (torch.Tensor, torch.IntTensor, float):

--- a/src/vqvae/transformer_stack.py
+++ b/src/vqvae/transformer_stack.py
@@ -63,10 +63,10 @@ class VanillaTransformerStack(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        attention_mask: torch.Tensor | None = None,
+        affine: Affine3D,
+        affine_mask: torch.Tensor,
+        attention_mask: torch.Tensor,
         sequence_id: torch.Tensor | None = None,
-        affine: Affine3D | None = None,
-        affine_mask: torch.Tensor | None = None,
         chain_id: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -75,8 +75,8 @@ class VanillaTransformerStack(nn.Module):
         Args:
             x (torch.Tensor): The input tensor of shape (batch_size, sequence_length, d_model).
             sequence_id (torch.Tensor): The sequence ID tensor of shape (batch_size, sequence_length).
-            affine (Affine3D | None): The affine transformation tensor or None.
-            affine_mask (torch.Tensor | None): The affine mask tensor or None.
+            affine (Affine3D): The affine transformation tensor or None.
+            affine_mask (torch.Tensor): The affine mask tensor or None.
             chain_id (torch.Tensor): The protein chain tensor of shape (batch_size, sequence_length).
                 Only used in geometric attention.
 

--- a/src/vqvae/transformer_stack.py
+++ b/src/vqvae/transformer_stack.py
@@ -75,8 +75,8 @@ class VanillaTransformerStack(nn.Module):
         Args:
             x (torch.Tensor): The input tensor of shape (batch_size, sequence_length, d_model).
             sequence_id (torch.Tensor): The sequence ID tensor of shape (batch_size, sequence_length).
-            affine (Affine3D): The affine transformation tensor or None.
-            affine_mask (torch.Tensor): The affine mask tensor or None.
+            affine (Affine3D): The affine transformation tensor.
+            affine_mask (torch.Tensor): The affine mask tensor.
             chain_id (torch.Tensor): The protein chain tensor of shape (batch_size, sequence_length).
                 Only used in geometric attention.
 


### PR DESCRIPTION
Bug fixes in vqvae module: adding bias to LayerNorm of VanillaMultiHeadAttention:__init__,  quantizer `indices2embedding` misuses `nn.Embedding` and `VanillaTransformerStack.forward` not forcing required arguments such as `affine`, `affine_mask`
